### PR TITLE
Display name and more menu fixes in the Thumbnail.

### DIFF
--- a/css/_avatar.scss
+++ b/css/_avatar.scss
@@ -30,6 +30,7 @@
     position: absolute;
     right: 0;
     top: 0;
+    color : #444444;
 }
 
 .avatar-svg {

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -649,7 +649,7 @@
 
 .display-name-on-black {
     .avatar-container {
-        visibility: hidden;
+        visibility: visible;
     }
 
     .displayNameContainer {
@@ -661,7 +661,7 @@
     }
 
     video {
-        opacity: 0.2;
+        opacity: 0.6;
         visibility: visible;
     }
 }
@@ -686,7 +686,7 @@
 
 .display-name-on-video {
     .avatar-container {
-        visibility: hidden;
+        visibility: visible;
     }
 
     .displayNameContainer {
@@ -694,10 +694,11 @@
     }
 
     .videocontainer__hoverOverlay {
-        visibility: visible;
+        visibility: hidden;
     }
 
     video {
+        opacity: 0.6;
         visibility: visible;
     }
 }

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -205,17 +205,6 @@ export default class RemoteVideo extends SmallVideo {
             <Provider store = { APP.store }>
                 <I18nextProvider i18n = { i18next }>
                     <AtlasKitThemeProvider mode = 'dark'>
-                        <RemoteVideoMenuTriggerButton
-                            initialVolumeValue = { initialVolumeValue }
-                            isAudioMuted = { this.isAudioMuted }
-                            isModerator = { isModerator }
-                            menuPosition = { remoteMenuPosition }
-                            onMenuDisplay
-                                = {this._onRemoteVideoMenuDisplay.bind(this)}
-                            onRemoteControlToggle = { onRemoteControlToggle }
-                            onVolumeChange = { onVolumeChange }
-                            participantID = { participantID }
-                            remoteControlState = { remoteControlState } />
                     </AtlasKitThemeProvider>
                 </I18nextProvider>
             </Provider>,

--- a/react/features/base/avatar/functions.js
+++ b/react/features/base/avatar/functions.js
@@ -58,5 +58,5 @@ export function getInitials(s: ?string) {
         (initials.length < 2) && (initials += w.substr(0, 1).toUpperCase());
     }
 
-    return initials;
+    return words;
 }

--- a/react/features/remote-video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/remote-video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -120,6 +120,7 @@ class RemoteVideoMenuTriggerButton extends Component<Props> {
         return (
             <Popover
                 content = { content }
+                disablePopover = { true }
                 onPopoverOpen = { this._onShowRemoteMenu }
                 position = { this.props.menuPosition }>
                 <span

--- a/react/features/remote-video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/remote-video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -120,7 +120,6 @@ class RemoteVideoMenuTriggerButton extends Component<Props> {
         return (
             <Popover
                 content = { content }
-                disablePopover = { true }
                 onPopoverOpen = { this._onShowRemoteMenu }
                 position = { this.props.menuPosition }>
                 <span


### PR DESCRIPTION
STORM-1189 : Web : Session : UserNames are not displayed in the thumbnail.
STORM-1197 : Web : Session : Mute and Unmute does not change the icon in user's thumbnail and always displays muted state.
STORM-1198: Web : Session : Mute from user's thumbnail does not actually mute the other user.
STORM-1199: Web : Session : Volume : Changing volume in user's thumbnail does not have any impact.
STORM:1200: Web : Session : Kickout : Host performing this action on participant does not have any impact.
STORM:1201: Web : Session : Kickout : This option is available for participant to kick out the host.
STORM:1202: Web : Session : More Menu (3 dots) : Mute using keyboard shortcut does not change the mute/unmute status of the user.
STORM:1203: Web : Session : More Menu (3 dots) : Submitting feedback continues to display the feedback pop-up and gets submitted only after session is ended.
STORM-1204: Web : Session : Schedule : Deleting number in passcode box switches to next box or number.
